### PR TITLE
Fix projectile_motion param name

### DIFF
--- a/pb2025_vision_bringup/params/reality/vision_params.yaml
+++ b/pb2025_vision_bringup/params/reality/vision_params.yaml
@@ -60,6 +60,6 @@ projectile_motion:
       target_frame: "gimbal_pitch"              # gimbal frame_id
       target_topic: "tracker/target"
       gimbal_cmd_topic: "cmd_gimbal_joint"
-      shoot_data_topic: "robot_shoot_data"
+      shoot_cmd_topic: "cmd_shoot"
       solver_type: "gravity"                    # projectile solve method: gravity / gaf
       # friction: 0.001                         # Air resistance factor if use GAF solver

--- a/pb2025_vision_bringup/params/simulation/vision_params.yaml
+++ b/pb2025_vision_bringup/params/simulation/vision_params.yaml
@@ -41,11 +41,11 @@ projectile_motion:
     projectile:
       offset_pitch: 0.0
       offset_yaw: 0.0
-      offset_time: 0.07
+      offset_time: 0.0
       initial_speed: 18.0
       target_frame: "gimbal_pitch"              # gimbal frame_id
       target_topic: "tracker/target"
       gimbal_cmd_topic: "cmd_gimbal_joint"
-      shoot_data_topic: "robot_shoot_data"
+      shoot_cmd_topic: "cmd_shoot"
       solver_type: "gravity"                    # projectile solve method: gravity / gaf
       # friction: 0.001                         # Air resistance factor if use GAF solver

--- a/projectile_motion/config/projectile_motion.yaml
+++ b/projectile_motion/config/projectile_motion.yaml
@@ -1,16 +1,14 @@
-/**:
+projectile_motion:
   ros__parameters:
+    use_sim_time: false
     projectile:
-      offset_x: 0.0
-      offset_y: 0.0
-      offset_z: 0.0
       offset_pitch: 0.0
       offset_yaw: 0.0
       offset_time: 0.0
-      initial_speed: 0.0
-      target_topic: 'processor/target'
-      gimbal_cmd_topic: 'gimbal_cmd'
-      shoot_data_topic: 'robot_shoot_data'
-      target_frame: 'shooter_link' # gimbal frame_id
-      solver_type: 'gravity' # projectile solve method: gravity / gaf
-      # friction: 0.001 # Air resistance factor if use GAF solver
+      initial_speed: 18.0
+      target_frame: "gimbal_pitch"              # gimbal frame_id
+      target_topic: "tracker/target"
+      gimbal_cmd_topic: "cmd_gimbal_joint"
+      shoot_cmd_topic: "cmd_shoot"
+      solver_type: "gravity"                    # projectile solve method: gravity / gaf
+      # friction: 0.001                         # Air resistance factor if use GAF solver

--- a/projectile_motion/src/projectile_motion_node.cpp
+++ b/projectile_motion/src/projectile_motion_node.cpp
@@ -85,7 +85,6 @@ void ProjectileMotionNode::targetCallback(const auto_aim_interfaces::msg::Target
 {
   if (!msg->tracking) {
     publishGimbalCommand(cur_pitch_, cur_yaw_, 0);
-    RCLCPP_INFO(get_logger(), "Pitch: %f, Yaw: %f", cur_pitch_, cur_yaw_);
     RCLCPP_INFO(get_logger(), "Target lost, stop tracking.");
     return;
   }


### PR DESCRIPTION
`shoot_data_topic` -> `shoot_cmd_topic`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized projectile motion settings by renaming communication channels for shooting commands across environments.
  - Adjusted key dynamics parameters, including reducing a timing offset, increasing initial launch speed, and revising target tracking details.
  - Removed an extraneous log message to streamline runtime feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->